### PR TITLE
Specify PHP version requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "type": "yii2-extension",
   "license": "MIT",
   "require": {
+    "php": "^7",
     "yiisoft/yii2": "^2",
     "w3lifer/php-helper": "^4"
   },


### PR DESCRIPTION
I thought this simple plugin supports PHP 5.6 like Yii2 does, apparently it doesn't because of the dependency `php-helper`.

It might be a good idea to state this requirement inside `composer.json`?